### PR TITLE
WIP: Be more detailed old chrome versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ dl { background-color: var(--color); color: var(--text); box-shadow: inset 1ch 1
     <div class="key">
         <h3>Key</h3>
         <div class="all"> Supported by all browsers including IE11</div>
-        <div class="allbutie11"> Supported by all browsers</div>
+        <div class="allbutie11"> Supported by all browsers<a href="#faq-allbutie11"><sup>1</sup></a></div>
         <div class="somebrowsers"> Supported by two modern browsers</div>
         <div class="inprogress"> Implementation is in progress</div>
         <div class="proposal"> Being discussed or proposed</div>
@@ -249,7 +249,7 @@ dl { background-color: var(--color); color: var(--text); box-shadow: inset 1ch 1
                 <dl class="somebrowsers">
                     <time>2020</time>
                     <dt>Nx</dt>
-                    <dd>ES.Next <code>Intl</code> <code>WeakRef</code> <code>Atomics</code> <code>??</code> <code>||=</code></dd>
+                    <dd>ES.Next <code>Intl</code> <code>WeakRef</code> <code>Atomics</code> <code>?.</code> <code>??</code> <code>||=</code></dd>
                 </dl>
                 <dl class="proposal">
                     <time><a href="https://docs.google.com/presentation/d/1kqtsJfLVC-Nmcm2sveMRdJPjurwKKiiCGilK2_ladpw/edit?usp=gmail&gxids=7628#slide=id.p">2020</a></time>
@@ -497,5 +497,8 @@ dl { background-color: var(--color); color: var(--text); box-shadow: inset 1ch 1
     <h3>What do the colors represent?</h3>
     <p>The lighter the color, the more support there is.</p>
     <p>The red represents how active the specification or proposal is.</p>
+    
+    <h3 id="faq-allbutie11"><sup>1</sup>What does "supported by all browsers" mean?</h3>
+    <p>As many as 3% of all Chrome users are still on Chrome 79-84 (two versions ago as of this writing) and sites will break for them if unsupported features are used.</p>
 </footer>
 </html>


### PR DESCRIPTION
I'm opening this because as the owner of a real-world site that tried to use optional chaining, which is only supported in Chrome 79, two out of ten initial testers reported problems accessing the site until I stopped using the feature. While my case was likely an outlier, it illustrates how old browser versions are still in use because their auto-update has failed or for whatever reason.

Contributions welcome to this branch– feel free to send a pull request to my pull request.

- A new key for browser features not supported for >99% of users, but supported by their latest versions
- Colors fading based on percent of users that can use the feature
- Other ideas? @codestance 